### PR TITLE
Add moderation commands to selfbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ This selfbot utilizes a local database and has the option to utilize external da
 - `!namehistory <user>`: Request a user's name history
 - `!avhistory <user>`: Request a user's avatar history
 - `!currentav <user>`: Request a user's current avatar
+- `!kick <user> [reason]`: Kick a user from the server
+- `!ban <user> [reason]`: Ban a user from the server
+- `!masskick <user1> <user2> ... [reason]`: Kick multiple users from the server
+- `!massban <user1> <user2> ... [reason]`: Ban multiple users from the server
+- `!kickrole <role> [reason]`: Kick all users with a specific role from the server
+- `!banrole <role> [reason]`: Ban all users with a specific role from the server
 
 The output will be formatted in codeblocks.
 

--- a/cogs/moderation_cog.py
+++ b/cogs/moderation_cog.py
@@ -1,0 +1,45 @@
+import discord
+from discord.ext import commands
+
+class ModerationCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(name='kick')
+    async def kick(self, ctx, user: discord.Member, *, reason=None):
+        await user.kick(reason=reason)
+        await ctx.send(f'Kicked {user.name} for reason: {reason}')
+
+    @commands.command(name='ban')
+    async def ban(self, ctx, user: discord.Member, *, reason=None):
+        await user.ban(reason=reason)
+        await ctx.send(f'Banned {user.name} for reason: {reason}')
+
+    @commands.command(name='masskick')
+    async def mass_kick(self, ctx, users: commands.Greedy[discord.Member], *, reason=None):
+        for user in users:
+            await user.kick(reason=reason)
+        await ctx.send(f'Kicked {len(users)} users for reason: {reason}')
+
+    @commands.command(name='massban')
+    async def mass_ban(self, ctx, users: commands.Greedy[discord.Member], *, reason=None):
+        for user in users:
+            await user.ban(reason=reason)
+        await ctx.send(f'Banned {len(users)} users for reason: {reason}')
+
+    @commands.command(name='kickrole')
+    async def kick_role(self, ctx, role: discord.Role, *, reason=None):
+        members = [member for member in ctx.guild.members if role in member.roles]
+        for member in members:
+            await member.kick(reason=reason)
+        await ctx.send(f'Kicked {len(members)} users with role {role.name} for reason: {reason}')
+
+    @commands.command(name='banrole')
+    async def ban_role(self, ctx, role: discord.Role, *, reason=None):
+        members = [member for member in ctx.guild.members if role in member.roles]
+        for member in members:
+            await member.ban(reason=reason)
+        await ctx.send(f'Banned {len(members)} users with role {role.name} for reason: {reason}')
+
+def setup(bot):
+    bot.add_cog(ModerationCog(bot))


### PR DESCRIPTION
Add moderation commands to the selfbot.

* **New ModerationCog**: Add `cogs/moderation_cog.py` with commands for kick, ban, mass kick, mass ban, and role-based kick/ban.
  - Implement `kick` command to kick a user.
  - Implement `ban` command to ban a user.
  - Implement `masskick` command to kick multiple users.
  - Implement `massban` command to ban multiple users.
  - Implement `kickrole` command to kick users with a specific role.
  - Implement `banrole` command to ban users with a specific role.

* **Main Bot File**: Modify `selfbot.py` to load the new `ModerationCog`.

* **Documentation**: Update `README.md` to include descriptions and usage of the new moderation commands.

