### PR TITLE
Improve error handling and add database selection logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This selfbot utilizes a local database and has the option to utilize external da
 - Stores username, avatar, and display name changes
 - Global error handler for better error management
 - Modularized database connection logic for better code organization
+- Determines which database to use if other databases aren't configured
+- Warns the user if other databases aren't set up and uses a local database
 
 ## Commands
 
@@ -36,6 +38,8 @@ To configure the selfbot, you need to provide the necessary database connection 
 - MongoDB
 - MySQL
 - Redis
+
+If no external databases are configured, the selfbot will set up a local database and warn the user.
 
 ## Setup and Running
 

--- a/selfbot.py
+++ b/selfbot.py
@@ -54,6 +54,12 @@ class SelfBot(commands.Bot):
         except redis.RedisError as e:
             print(f"Redis error: {e}")
 
+        # Check if any database is configured
+        if not any([self.local_db_conn, self.mongo_client, self.mysql_conn, self.redis_client]):
+            print("No external databases configured. Setting up a local database.")
+            self.local_db_conn = sqlite3.connect("default_local_db.sqlite")
+            print("Warning: Using local database as no other databases are configured.")
+
     def load_cogs(self):
         for filename in os.listdir('./cogs'):
             if filename.endswith('.py'):

--- a/utils/database.py
+++ b/utils/database.py
@@ -8,33 +8,58 @@ from dotenv import load_dotenv
 load_dotenv()
 
 def connect_sqlite():
-    if os.getenv("LOCAL_DB_PATH"):
-        return sqlite3.connect(os.getenv("LOCAL_DB_PATH"))
+    try:
+        if os.getenv("LOCAL_DB_PATH"):
+            return sqlite3.connect(os.getenv("LOCAL_DB_PATH"))
+    except sqlite3.Error as e:
+        print(f"SQLite error: {e}")
     return None
 
 def connect_mongodb():
-    if os.getenv("MONGODB_URI"):
-        return pymongo.MongoClient(os.getenv("MONGODB_URI"))
+    try:
+        if os.getenv("MONGODB_URI"):
+            return pymongo.MongoClient(os.getenv("MONGODB_URI"))
+    except pymongo.errors.PyMongoError as e:
+        print(f"MongoDB error: {e}")
     return None
 
 def connect_mysql():
-    if os.getenv("MYSQL_HOST"):
-        return mysql.connector.connect(
-            host=os.getenv("MYSQL_HOST"),
-            user=os.getenv("MYSQL_USER"),
-            password=os.getenv("MYSQL_PASSWORD"),
-            database=os.getenv("MYSQL_DATABASE")
-        )
+    try:
+        if os.getenv("MYSQL_HOST"):
+            return mysql.connector.connect(
+                host=os.getenv("MYSQL_HOST"),
+                user=os.getenv("MYSQL_USER"),
+                password=os.getenv("MYSQL_PASSWORD"),
+                database=os.getenv("MYSQL_DATABASE")
+            )
+    except mysql.connector.Error as e:
+        print(f"MySQL error: {e}")
     return None
 
 def connect_redis():
-    if os.getenv("REDIS_HOST"):
-        return redis.StrictRedis(
-            host=os.getenv("REDIS_HOST"),
-            port=os.getenv("REDIS_PORT"),
-            password=os.getenv("REDIS_PASSWORD")
-        )
+    try:
+        if os.getenv("REDIS_HOST"):
+            return redis.StrictRedis(
+                host=os.getenv("REDIS_HOST"),
+                port=os.getenv("REDIS_PORT"),
+                password=os.getenv("REDIS_PASSWORD")
+            )
+    except redis.RedisError as e:
+        print(f"Redis error: {e}")
     return None
+
+def determine_database():
+    local_db_conn = connect_sqlite()
+    mongo_client = connect_mongodb()
+    mysql_conn = connect_mysql()
+    redis_client = connect_redis()
+
+    if not any([local_db_conn, mongo_client, mysql_conn, redis_client]):
+        print("No external databases configured. Setting up a local database.")
+        local_db_conn = sqlite3.connect("default_local_db.sqlite")
+        print("Warning: Using local database as no other databases are configured.")
+
+    return local_db_conn, mongo_client, mysql_conn, redis_client
 
 def fetch_avatar_history_sqlite(conn, user_id):
     cursor = conn.cursor()


### PR DESCRIPTION
Add error handling and logic for determining which database to use if other databases aren't configured, and warn the user if other databases aren't set up.

* **selfbot.py**
  - Add logic to check if any database is configured and set up a local database if none are configured.
  - Add warning messages to notify the user if other databases aren't set up and the bot is using the local database.

* **utils/database.py**
  - Add error handling for SQLite, MongoDB, MySQL, and Redis connections.
  - Add logic to determine which database to use if other databases aren't configured.

* **README.md**
  - Update information about the new error handling and database selection logic.
  - Add note about the bot setting up a local database if no external databases are configured.

