### PR TITLE
Add custom activity status with rich presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This selfbot utilizes a local database and has the option to utilize external da
 - `!massban <user1> <user2> ... [reason]`: Ban multiple users from the server
 - `!kickrole <role> [reason]`: Kick all users with a specific role from the server
 - `!banrole <role> [reason]`: Ban all users with a specific role from the server
+- `!setactivity <activity_type> <activity_name>`: Set a custom activity status
+- `!clearactivity`: Clear the custom activity status
 
 The output will be formatted in codeblocks.
 
@@ -108,6 +110,16 @@ Here are some examples of how to use the commands:
 - Ban all users with a specific role from the server:
   ```
   !banrole @role [reason]
+  ```
+
+- Set a custom activity status:
+  ```
+  !setactivity playing Minecraft
+  ```
+
+- Clear the custom activity status:
+  ```
+  !clearactivity
   ```
 
 ## Library

--- a/cogs/custom_activity_cog.py
+++ b/cogs/custom_activity_cog.py
@@ -1,0 +1,32 @@
+import discord
+from discord.ext import commands
+
+class CustomActivityCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(name='setactivity')
+    async def set_activity(self, ctx, activity_type: str, *, activity_name: str):
+        activity = None
+        if activity_type.lower() == 'playing':
+            activity = discord.Game(name=activity_name)
+        elif activity_type.lower() == 'streaming':
+            activity = discord.Streaming(name=activity_name, url="https://twitch.tv/streamer")
+        elif activity_type.lower() == 'listening':
+            activity = discord.Activity(type=discord.ActivityType.listening, name=activity_name)
+        elif activity_type.lower() == 'watching':
+            activity = discord.Activity(type=discord.ActivityType.watching, name=activity_name)
+        else:
+            await ctx.send("Invalid activity type. Please choose from playing, streaming, listening, or watching.")
+            return
+
+        await self.bot.change_presence(activity=activity)
+        await ctx.send(f"Activity set to {activity_type} {activity_name}")
+
+    @commands.command(name='clearactivity')
+    async def clear_activity(self, ctx):
+        await self.bot.change_presence(activity=None)
+        await ctx.send("Activity cleared")
+
+def setup(bot):
+    bot.add_cog(CustomActivityCog(bot))


### PR DESCRIPTION
Add functionality for users to set and clear custom activity status with rich presence using the selfbot.

* **New Cog**: Add `cogs/custom_activity_cog.py` to handle custom activity status commands.
  - Define `CustomActivityCog` class with `setactivity` and `clearactivity` commands.
  - Implement logic to set custom activity status based on activity type (playing, streaming, listening, watching).
  - Implement logic to clear custom activity status.

* **README Update**: Update `README.md` to document new `setactivity` and `clearactivity` commands.
  - Add command descriptions under the command list.
  - Provide examples for setting and clearing custom activity status.

