### PR TITLE
Default to selfbot user if no user is mentioned

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ This selfbot utilizes a local database and has the option to utilize external da
 
 ## Commands
 
-- `!namehistory <user>`: Request a user's name history
-- `!avhistory <user>`: Request a user's avatar history
-- `!currentav <user>`: Request a user's current avatar
+- `!namehistory [user]`: Request a user's name history. Defaults to the selfbot user if no user is mentioned.
+- `!avhistory [user]`: Request a user's avatar history. Defaults to the selfbot user if no user is mentioned.
+- `!currentav [user]`: Request a user's current avatar. Defaults to the selfbot user if no user is mentioned.
 - `!kick <user> [reason]`: Kick a user from the server
 - `!ban <user> [reason]`: Ban a user from the server
 - `!masskick <user1> <user2> ... [reason]`: Kick multiple users from the server

--- a/cogs/avatar_history_cog.py
+++ b/cogs/avatar_history_cog.py
@@ -22,7 +22,9 @@ class AvatarHistoryCog(commands.Cog):
         self.local_cache = bot.local_cache
 
     @commands.command(name='avhistory')
-    async def avatar_history(self, ctx, user: discord.User):
+    async def avatar_history(self, ctx, user: discord.User = None):
+        if user is None:
+            user = ctx.author
         avatar_history = self.fetch_avatar_history(user.id)
         if avatar_history:
             await ctx.send(f"Here's the avatar history for {user.name}: {', '.join(avatar_history)}")

--- a/cogs/current_avatar_cog.py
+++ b/cogs/current_avatar_cog.py
@@ -6,7 +6,9 @@ class CurrentAvatarCog(commands.Cog):
         self.bot = bot
 
     @commands.command(name='currentav')
-    async def current_avatar(self, ctx, user: discord.User):
+    async def current_avatar(self, ctx, user: discord.User = None):
+        if user is None:
+            user = ctx.author
         await ctx.send(f"Hey there! Here's the current avatar for {user.name}: {user.avatar_url}")
 
 def setup(bot):

--- a/cogs/name_history_cog.py
+++ b/cogs/name_history_cog.py
@@ -22,7 +22,9 @@ class NameHistoryCog(commands.Cog):
         self.local_cache = bot.local_cache
 
     @commands.command(name='namehistory')
-    async def name_history(self, ctx, user: discord.User):
+    async def name_history(self, ctx, user: discord.User = None):
+        if user is None:
+            user = ctx.author
         name_history = self.fetch_name_history(user.id)
         if name_history:
             await ctx.send(f"Here's the name history for {user.name}: {', '.join(name_history)}")


### PR DESCRIPTION
Update commands to default to selfbot user if no user is mentioned.

* **avatar_history_cog.py**
  - Update `avatar_history` command to default to selfbot user if no user is mentioned.
  - Add check to set `user` to `ctx.author` if `user` is `None`.

* **current_avatar_cog.py**
  - Update `current_avatar` command to default to selfbot user if no user is mentioned.
  - Add check to set `user` to `ctx.author` if `user` is `None`.

* **name_history_cog.py**
  - Update `name_history` command to default to selfbot user if no user is mentioned.
  - Add check to set `user` to `ctx.author` if `user` is `None`.

* **README.md**
  - Update command descriptions to reflect new behavior of defaulting to selfbot user when no user is mentioned.

