### PR TITLE
Shorten the README and make it more user friendly

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,0 +1,37 @@
+# Command Examples
+
+## Basic Commands
+
+- `!namehistory [user]`: Request a user's name history. Defaults to the selfbot user if no user is mentioned.
+- `!avhistory [user]`: Request a user's avatar history. Defaults to the selfbot user if no user is mentioned.
+- `!currentav [user]`: Request a user's current avatar. Defaults to the selfbot user if no user is mentioned.
+- `!kick <user> [reason]`: Kick a user from the server
+- `!ban <user> [reason]`: Ban a user from the server
+- `!masskick <user1> <user2> ... [reason]`: Kick multiple users from the server
+- `!massban <user1> <user2> ... [reason]`: Ban multiple users from the server
+- `!kickrole <role> [reason]`: Kick all users with a specific role from the server
+- `!banrole <role> [reason]`: Ban all users with a specific role from the server
+- `!setactivity <activity_type> <activity_name>`: Set a custom activity status
+- `!clearactivity`: Clear the custom activity status
+
+## Rich Presence Elements
+
+### Playing
+
+- `!setactivity playing <game_name>`: Set the activity to "Playing <game_name>".
+
+### Streaming
+
+- `!setactivity streaming <stream_name> url=<stream_url>`: Set the activity to "Streaming <stream_name>" with the specified URL.
+
+### Listening
+
+- `!setactivity listening <music_name>`: Set the activity to "Listening to <music_name>".
+
+### Watching
+
+- `!setactivity watching <show_name>`: Set the activity to "Watching <show_name>".
+
+### Custom
+
+- `!setactivity custom <custom_name> state=<state> details=<details> application_id=<application_id> url=<url> timestamps=<timestamps> assets=<assets> party=<party> secrets=<secrets> instance=<instance> buttons=<buttons>`: Set a custom activity with the specified parameters.

--- a/README.md
+++ b/README.md
@@ -19,33 +19,6 @@ This selfbot utilizes a local database and has the option to utilize external da
 - Redis caching for avatar and name history
 - Caching for other functionalities even if no external database is set up
 
-## Commands
-
-- `!namehistory [user]`: Request a user's name history. Defaults to the selfbot user if no user is mentioned.
-- `!avhistory [user]`: Request a user's avatar history. Defaults to the selfbot user if no user is mentioned.
-- `!currentav [user]`: Request a user's current avatar. Defaults to the selfbot user if no user is mentioned.
-- `!kick <user> [reason]`: Kick a user from the server
-- `!ban <user> [reason]`: Ban a user from the server
-- `!masskick <user1> <user2> ... [reason]`: Kick multiple users from the server
-- `!massban <user1> <user2> ... [reason]`: Ban multiple users from the server
-- `!kickrole <role> [reason]`: Kick all users with a specific role from the server
-- `!banrole <role> [reason]`: Ban all users with a specific role from the server
-- `!setactivity <activity_type> <activity_name>`: Set a custom activity status
-- `!clearactivity`: Clear the custom activity status
-
-The output will be formatted in codeblocks.
-
-## Configuration
-
-To configure the selfbot, you need to provide the necessary database connection details in the `.env` file. The selfbot supports the following configuration options:
-
-- Local database
-- MongoDB
-- MySQL
-- Redis (used as a cache)
-
-If no external databases are configured, the selfbot will set up a local database and warn the user. Redis will be used as a cache for avatar and name history, as well as other functionalities. If Redis is not set up, an alternative caching mechanism will be used.
-
 ## Setup and Running
 
 1. Clone the repository:
@@ -66,98 +39,18 @@ If no external databases are configured, the selfbot will set up a local databas
    python selfbot.py
    ```
 
-## Examples
+## Basic Usage
 
-Here are some examples of how to use the commands:
+- `!namehistory [user]`: Request a user's name history. Defaults to the selfbot user if no user is mentioned.
+- `!avhistory [user]`: Request a user's avatar history. Defaults to the selfbot user if no user is mentioned.
+- `!currentav [user]`: Request a user's current avatar. Defaults to the selfbot user if no user is mentioned.
+- `!kick <user> [reason]`: Kick a user from the server
+- `!ban <user> [reason]`: Ban a user from the server
+- `!masskick <user1> <user2> ... [reason]`: Kick multiple users from the server
+- `!massban <user1> <user2> ... [reason]`: Ban multiple users from the server
+- `!kickrole <role> [reason]`: Kick all users with a specific role from the server
+- `!banrole <role> [reason]`: Ban all users with a specific role from the server
+- `!setactivity <activity_type> <activity_name>`: Set a custom activity status
+- `!clearactivity`: Clear the custom activity status
 
-- Request a user's name history:
-  ```
-  !namehistory @username
-  ```
-
-- Request a user's avatar history:
-  ```
-  !avhistory @username
-  ```
-
-- Request a user's current avatar:
-  ```
-  !currentav @username
-  ```
-
-- Kick a user from the server:
-  ```
-  !kick @username [reason]
-  ```
-
-- Ban a user from the server:
-  ```
-  !ban @username [reason]
-  ```
-
-- Kick multiple users from the server:
-  ```
-  !masskick @username1 @username2 ... [reason]
-  ```
-
-- Ban multiple users from the server:
-  ```
-  !massban @username1 @username2 ... [reason]
-  ```
-
-- Kick all users with a specific role from the server:
-  ```
-  !kickrole @role [reason]
-  ```
-
-- Ban all users with a specific role from the server:
-  ```
-  !banrole @role [reason]
-  ```
-
-- Set a custom activity status:
-  ```
-  !setactivity playing Minecraft
-  ```
-
-- Clear the custom activity status:
-  ```
-  !clearactivity
-  ```
-
-## Rich Presence Elements
-
-The custom activity now supports setting rich presence elements. Here are the available elements and their descriptions:
-
-- `status`: Enable or disable the status (True/False)
-- `presence`: Enable or disable the presence (True/False)
-- `type`: The type of activity (e.g., gaming, streaming, etc.)
-- `mode`: The mode of the activity (e.g., idle, dnd, etc.)
-- `application_id`: The application ID for the activity
-- `url`: The URL for the activity (requires a valid Twitch stream URL)
-- `details`: Additional details about the activity
-- `state`: The state of the activity
-- `name`: The name of the activity
-- `timestamp`: Enable or disable the timestamp (True/False)
-- `hidden`: Hide or show the activity (True/False)
-- `party`: Enable or disable the party (True/False)
-- `party_size_min`: The minimum party size
-- `party_size_max`: The maximum party size
-- `small_text`: Small text for the activity
-- `large_text`: Large text for the activity
-- `small_image_key`: The key for the small image
-- `large_image_key`: The key for the large image
-- `button_one`: The first button (URL and text)
-- `button_two`: The second button (URL and text)
-
-## Storing Custom Activity Settings
-
-To store custom activity settings so they persist across sessions, the selfbot supports storing the settings in both local and external databases. The settings will be loaded on startup and saved when they are set.
-
-## Library
-
-This selfbot utilizes the `discord.py-self` library for its functionality.
-
-## Contributing
-
-We welcome contributions to the selfbot project! If you would like to contribute, please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file for detailed instructions on how to get started.
+For detailed command examples and rich presence elements, please refer to the [COMMANDS.md](COMMANDS.md) file.


### PR DESCRIPTION
Shorten the `README.md` and make it more user-friendly by focusing on essential information and moving detailed examples to a new file.

* **README.md**
  - Remove detailed command examples and rich presence elements.
  - Simplify setup and running instructions.
  - Add a link to the new `COMMANDS.md` file for detailed command examples and rich presence elements.

* **COMMANDS.md**
  - Add detailed command examples.
  - Add rich presence elements section.

