### PR TITLE
Fix pytest command not found for the actions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pymongo
 mysql-connector-python
 redis
 python-dotenv
+pytest


### PR DESCRIPTION
Add `pytest` to the list of dependencies in `requirements.txt`.

* Ensure `pytest` is available for the `Run tests` step in the GitHub Actions workflow file `.github/workflows/auto_merge.yml`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/outmaneuver/selfbot?shareId=16a0935c-a211-43d4-a15f-598e890fd9fa).