### PR TITLE
Add purge cog to selfbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This selfbot utilizes a local database and has the option to utilize external da
 - `!banrole <role> [reason]`: Ban all users with a specific role from the server
 - `!setactivity <activity_type> <activity_name>`: Set a custom activity status
 - `!clearactivity`: Clear the custom activity status
+- `!purge [channel_id] [delay]`: Purge a selfbot user's messages in a specified channel with an optional delay between deletions. If no channel ID is provided, it will purge messages in the current channel. The delay is in seconds and defaults to 1.0.
 
 ## Rich Presence Elements
 

--- a/cogs/purge_cog.py
+++ b/cogs/purge_cog.py
@@ -1,0 +1,32 @@
+import discord
+from discord.ext import commands
+from utils.rate_limiter import RateLimiter
+import asyncio
+
+class PurgeCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.rate_limiter = RateLimiter()
+
+    @commands.command(name='purge')
+    async def purge(self, ctx, channel_id: int = None, delay: float = 1.0):
+        if channel_id is None:
+            channel = ctx.channel
+        else:
+            channel = self.bot.get_channel(channel_id)
+
+        if channel is None:
+            await ctx.send("Invalid channel ID.")
+            return
+
+        def is_selfbot_message(message):
+            return message.author == self.bot.user
+
+        async for message in channel.history(limit=None):
+            if is_selfbot_message(message):
+                await self.rate_limiter.wait()
+                await message.delete()
+                await asyncio.sleep(delay)
+
+def setup(bot):
+    bot.add_cog(PurgeCog(bot))


### PR DESCRIPTION
Add a purge cog to allow purging a selfbot user's messages with a specified delay and rate limiter.

* **New Purge Cog**: Add `cogs/purge_cog.py` to implement the purge functionality with delay and rate limiter.
* **Bot Initialization**: Modify `selfbot.py` to load the new purge cog.
* **Documentation**: Update `README.md` to include usage instructions for the `purge` command.

