### PR TITLE
Fix the check for conflicts with base branch

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -31,7 +31,7 @@ jobs:
           git fetch origin
           git checkout ${{ github.event.pull_request.base.ref }}
           git merge --no-commit --no-ff ${{ github.event.pull_request.head.ref }}
-          git merge --abort || exit 1
+          git merge --abort || { echo "Merge conflict detected"; exit 1; }
 
   auto_merge:
     needs: run_checks

--- a/README.md
+++ b/README.md
@@ -86,3 +86,5 @@ The workflow is triggered on pull request events and includes the following jobs
 2. **Automatic Merge**: If all checks pass, this job automatically merges the pull request.
 
 To configure the workflow, make sure to update the `.github/workflows/auto_merge.yml` file with the appropriate settings for your project.
+
+The check for conflicts with the base branch is implemented in the GitHub Actions workflow file `.github/workflows/auto_merge.yml`. The current implementation fetches the base branch, checks out the base branch, and attempts to merge the head branch without committing or fast-forwarding. If a conflict is detected during the merge attempt, the merge is aborted, and the workflow exits with a non-zero status. The check for conflicts is located in the `run_checks` job under the `Check for conflicts with base branch` step in `.github/workflows/auto_merge.yml`. The `git merge --abort || exit 1` command is now replaced with `git merge --abort || { echo "Merge conflict detected"; exit 1; }` to provide a clear message.


### PR DESCRIPTION
Update the conflict check in the GitHub Actions workflow to provide a clear message when a merge conflict is detected.

* **README.md**
  - Add a description of the conflict check implementation and the new message for merge conflicts.

* **.github/workflows/auto_merge.yml**
  - Replace `git merge --abort || exit 1` with `git merge --abort || { echo "Merge conflict detected"; exit 1; }` in the `run_checks` job to provide a clear message when a merge conflict is detected.

