### PR TITLE
Fix selfbot permissions and replace embeds with codeblocks

### DIFF
--- a/cogs/autoreact_cog.py
+++ b/cogs/autoreact_cog.py
@@ -1,0 +1,50 @@
+import discord
+from discord.ext import commands
+from utils.rate_limiter import RateLimiter
+import asyncio
+
+class AutoReactCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.user_reactions = {}
+        self.rate_limiter = RateLimiter()
+
+    @commands.command(name='react')
+    async def react(self, ctx, user_ids: commands.Greedy[int], *emojis):
+        if not user_ids:
+            user_ids = [ctx.author.id]
+
+        for user_id in user_ids:
+            if user_id not in self.user_reactions:
+                self.user_reactions[user_id] = set()
+            self.user_reactions[user_id].update(emojis)
+
+        await ctx.send(f"Auto-react enabled for users: {', '.join(map(str, user_ids))} with emojis: {', '.join(emojis)}")
+
+    @commands.command(name='reactstop')
+    async def react_stop(self, ctx, user_id: int):
+        if user_id in self.user_reactions:
+            del self.user_reactions[user_id]
+            await ctx.send(f"Auto-react disabled for user: {user_id}")
+        else:
+            await ctx.send(f"No auto-react found for user: {user_id}")
+
+    @commands.command(name='reactlist')
+    async def react_list(self, ctx):
+        if self.user_reactions:
+            response = "Auto-react enabled for the following users:\n"
+            for user_id, emojis in self.user_reactions.items():
+                response += f"User ID: {user_id}, Emojis: {', '.join(emojis)}\n"
+            await ctx.send(f"```{response}```")
+        else:
+            await ctx.send("No users have auto-react enabled.")
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        if message.author.id in self.user_reactions:
+            for emoji in self.user_reactions[message.author.id]:
+                await self.rate_limiter.wait()
+                await message.add_reaction(emoji)
+
+def setup(bot):
+    bot.add_cog(AutoReactCog(bot))

--- a/cogs/avatar_history_cog.py
+++ b/cogs/avatar_history_cog.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 from utils.database import fetch_avatar_history
 from utils.error_handler import error_handler
+from utils.permissions import has_permissions_to_send_messages
 
 class AvatarHistoryCog(commands.Cog):
     def __init__(self, bot):
@@ -10,6 +11,7 @@ class AvatarHistoryCog(commands.Cog):
 
     @commands.command(name='avhistory')
     @error_handler
+    @has_permissions_to_send_messages()
     async def avatar_history(self, ctx, user: discord.User = None):
         if user is None:
             user = ctx.author

--- a/cogs/current_avatar_cog.py
+++ b/cogs/current_avatar_cog.py
@@ -1,11 +1,13 @@
 import discord
 from discord.ext import commands
+from utils.permissions import has_permissions_to_send_messages
 
 class CurrentAvatarCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
     @commands.command(name='currentav')
+    @has_permissions_to_send_messages()
     async def current_avatar(self, ctx, user: discord.User = None):
         if user is None:
             user = ctx.author

--- a/cogs/custom_activity_cog.py
+++ b/cogs/custom_activity_cog.py
@@ -1,6 +1,7 @@
 import discord
 from discord.ext import commands
 from utils.error_handler import error_handler
+from utils.permissions import has_permissions_to_send_messages
 
 class CustomActivityCog(commands.Cog):
     def __init__(self, bot):
@@ -8,6 +9,7 @@ class CustomActivityCog(commands.Cog):
 
     @commands.command(name='setactivity')
     @error_handler
+    @has_permissions_to_send_messages()
     async def set_activity(self, ctx, activity_type: str, activity_name: str = None):
         activity = None
         if activity_type.lower() == 'playing':
@@ -29,6 +31,7 @@ class CustomActivityCog(commands.Cog):
 
     @commands.command(name='clearactivity')
     @error_handler
+    @has_permissions_to_send_messages()
     async def clear_activity(self, ctx):
         await self.bot.change_presence(activity=None)
         await ctx.send("Activity cleared")

--- a/cogs/help_cog.py
+++ b/cogs/help_cog.py
@@ -1,6 +1,7 @@
 import discord
 from discord.ext import commands
 from utils.error_handler import error_handler
+import os
 
 class HelpCog(commands.Cog):
     def __init__(self, bot):
@@ -13,22 +14,24 @@ class HelpCog(commands.Cog):
         version = "1.0"
         author = os.getenv("AUTHOR")
 
+        if not ctx.channel.permissions_for(ctx.author).send_messages:
+            await ctx.author.send("You do not have permission to send messages in this channel.")
+            return
+
         if not input:
             # No input, show all categories and commands
-            embed = discord.Embed(title="Help", description=f"Use `{prefix}help <category>` to get more information on a category.", color=discord.Color.blue())
-            cogs_desc = ''
+            help_message = "Help\nUse `{prefix}help <category>` to get more information on a category.\n\nCategories:\n"
             for cog in self.bot.cogs:
-                cogs_desc += f'`{cog}` {self.bot.cogs[cog].__doc__}\n'
-            embed.add_field(name='Categories', value=cogs_desc, inline=False)
-            await ctx.send(embed=embed)
+                help_message += f'`{cog}` {self.bot.cogs[cog].__doc__}\n'
+            await ctx.send(f"```{help_message}```")
         elif len(input) == 1:
             # One input, show commands in the category
             cog = self.bot.get_cog(input[0])
             if cog:
-                embed = discord.Embed(title=f"{input[0]} - Commands", description=cog.__doc__, color=discord.Color.blue())
+                help_message = f"{input[0]} - Commands\n{cog.__doc__}\n\n"
                 for command in cog.get_commands():
-                    embed.add_field(name=f"`{prefix}{command.name}`", value=command.help, inline=False)
-                await ctx.send(embed=embed)
+                    help_message += f"`{prefix}{command.name}`: {command.help}\n"
+                await ctx.send(f"```{help_message}```")
             else:
                 await ctx.send(f"Category `{input[0]}` not found.")
         else:

--- a/cogs/list_cog.py
+++ b/cogs/list_cog.py
@@ -1,0 +1,24 @@
+import discord
+from discord.ext import commands
+
+class ListCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(name='list')
+    async def list_command(self, ctx):
+        autoreact_cog = self.bot.get_cog('AutoReactCog')
+        if autoreact_cog:
+            user_reactions = autoreact_cog.user_reactions
+            if user_reactions:
+                response = "Auto-react enabled for the following users:\n"
+                for user_id, emojis in user_reactions.items():
+                    response += f"User ID: {user_id}, Emojis: {', '.join(emojis)}\n"
+                await ctx.send(f"```{response}```")
+            else:
+                await ctx.send("No users have auto-react enabled.")
+        else:
+            await ctx.send("AutoReactCog is not loaded.")
+
+def setup(bot):
+    bot.add_cog(ListCog(bot))

--- a/cogs/moderation_cog.py
+++ b/cogs/moderation_cog.py
@@ -1,6 +1,7 @@
 import discord
 from discord.ext import commands
 from utils.error_handler import error_handler
+from utils.permissions import has_permissions_to_send_messages
 
 class ModerationCog(commands.Cog):
     def __init__(self, bot):
@@ -16,32 +17,38 @@ class ModerationCog(commands.Cog):
 
     @commands.command(name='kick')
     @error_handler
+    @has_permissions_to_send_messages()
     async def kick(self, ctx, user: discord.Member, *, reason=None):
         await self._kick_or_ban(ctx, [user], 'kick', reason)
 
     @commands.command(name='ban')
     @error_handler
+    @has_permissions_to_send_messages()
     async def ban(self, ctx, user: discord.Member, *, reason=None):
         await self._kick_or_ban(ctx, [user], 'ban', reason)
 
     @commands.command(name='masskick')
     @error_handler
+    @has_permissions_to_send_messages()
     async def mass_kick(self, ctx, users: commands.Greedy[discord.Member], *, reason=None):
         await self._kick_or_ban(ctx, users, 'kick', reason)
 
     @commands.command(name='massban')
     @error_handler
+    @has_permissions_to_send_messages()
     async def mass_ban(self, ctx, users: commands.Greedy[discord.Member], *, reason=None):
         await self._kick_or_ban(ctx, users, 'ban', reason)
 
     @commands.command(name='kickrole')
     @error_handler
+    @has_permissions_to_send_messages()
     async def kick_role(self, ctx, role: discord.Role, *, reason=None):
         members = [member for member in ctx.guild.members if role in member.roles]
         await self._kick_or_ban(ctx, members, 'kick', reason)
 
     @commands.command(name='banrole')
     @error_handler
+    @has_permissions_to_send_messages()
     async def ban_role(self, ctx, role: discord.Role, *, reason=None):
         members = [member for member in ctx.guild.members if role in member.roles]
         await self._kick_or_ban(ctx, members, 'ban', reason)

--- a/cogs/name_history_cog.py
+++ b/cogs/name_history_cog.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 from utils.database import fetch_name_history
 from utils.error_handler import error_handler
+from utils.permissions import has_permissions_to_send_messages
 
 class NameHistoryCog(commands.Cog):
     def __init__(self, bot):
@@ -10,6 +11,7 @@ class NameHistoryCog(commands.Cog):
 
     @commands.command(name='namehistory')
     @error_handler
+    @has_permissions_to_send_messages()
     async def name_history(self, ctx, user: discord.User = None):
         if user is None:
             user = ctx.author

--- a/cogs/reactstop_cog.py
+++ b/cogs/reactstop_cog.py
@@ -1,0 +1,21 @@
+import discord
+from discord.ext import commands
+
+class ReactStopCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(name='reactstop')
+    async def react_stop(self, ctx, user_id: int):
+        autoreact_cog = self.bot.get_cog('AutoReactCog')
+        if autoreact_cog:
+            if user_id in autoreact_cog.user_reactions:
+                del autoreact_cog.user_reactions[user_id]
+                await ctx.send(f"Auto-react disabled for user: {user_id}")
+            else:
+                await ctx.send(f"No auto-react found for user: {user_id}")
+        else:
+            await ctx.send("AutoReactCog is not loaded.")
+
+def setup(bot):
+    bot.add_cog(ReactStopCog(bot))

--- a/utils/permissions.py
+++ b/utils/permissions.py
@@ -1,0 +1,26 @@
+import discord
+from discord.ext import commands
+
+def has_permissions_to_send_messages():
+    async def predicate(ctx):
+        if not ctx.channel.permissions_for(ctx.author).send_messages:
+            await ctx.author.send("You do not have permission to send messages in this channel.")
+            return False
+        return True
+    return commands.check(predicate)
+
+def has_permissions_to_send_images():
+    async def predicate(ctx):
+        if not ctx.channel.permissions_for(ctx.author).attach_files:
+            await ctx.author.send("You do not have permission to send images in this channel.")
+            return False
+        return True
+    return commands.check(predicate)
+
+def has_permissions_to_use_external_emojis():
+    async def predicate(ctx):
+        if not ctx.channel.permissions_for(ctx.author).use_external_emojis:
+            await ctx.author.send("You do not have permission to use external emojis in this channel.")
+            return False
+        return True
+    return commands.check(predicate)


### PR DESCRIPTION
Replace embeds with well-formatted codeblocks and add permission checks for sending messages.

* **HelpCog**:
  - Replace embeds with well-formatted codeblocks in `help_command` method.
  - Add check for user permissions to send messages before sending.

* **AvatarHistoryCog**:
  - Add check for user permissions to send messages before sending.

* **NameHistoryCog**:
  - Add check for user permissions to send messages before sending.

* **CurrentAvatarCog**:
  - Add check for user permissions to send messages before sending.

* **CustomActivityCog**:
  - Add check for user permissions to send messages before sending.

* **ModerationCog**:
  - Add check for user permissions to send messages before performing actions.

* **AutoReactCog**:
  - Implement autoreact functionality with `!react` command.
  - Store user IDs and emojis for autoreacting.
  - Add ratelimiter to avoid getting ratelimited for reacting too fast.

* **ListCog**:
  - Implement list functionality to return users enabled for autoreacting.

* **ReactStopCog**:
  - Implement reactstop functionality to stop reacting for a user.

* **Permissions**:
  - Add a global decorator to check user permissions to send images, messages, or use external emotes.

