### PR TITLE
Hardcode GitHub author as outmaneuver

### DIFF
--- a/.env
+++ b/.env
@@ -21,6 +21,3 @@ MYSQL_DATABASE=your_mysql_database
 REDIS_HOST=your_redis_host
 REDIS_PORT=your_redis_port
 REDIS_PASSWORD=your_redis_password
-
-# Author configuration
-AUTHOR=your_github_username

--- a/cogs/utility/help_cog.py
+++ b/cogs/utility/help_cog.py
@@ -1,7 +1,6 @@
 import discord
 from discord.ext import commands
 from utils.error_handler import error_handler
-import os
 
 class HelpCog(commands.Cog):
     def __init__(self, bot):
@@ -12,7 +11,7 @@ class HelpCog(commands.Cog):
     async def help_command(self, ctx, *input):
         prefix = self.bot.command_prefix
         version = "1.0"
-        author = os.getenv("AUTHOR")
+        author = "outmaneuver"
 
         if not ctx.channel.permissions_for(ctx.author).send_messages:
             await ctx.author.send("You do not have permission to send messages in this channel.")


### PR DESCRIPTION
Hardcode the GitHub author as "outmaneuver" in the help command.

* Remove the `AUTHOR` environment variable from the `.env` file.
* Remove the import of `os` in `cogs/utility/help_cog.py`.
* Set the `author` variable to "outmaneuver" in the `help_command` method of `cogs/utility/help_cog.py`.

