### PR TITLE
Migrate to bun

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,4 +40,13 @@ To ensure the quality and consistency of the codebase, please follow these guide
 1. **Testing**: Write tests for any new features or bug fixes. Use a testing framework like Jest or Mocha for your tests. Ensure that all tests pass before submitting your pull request.
 2. **Linting**: Use a linter like ESLint to check your code for style and formatting issues. Ensure that your code follows the project's coding standards and passes the linting checks.
 
+## Using Bun
+
+To contribute to this project, you will need to use Bun instead of npm. Here are the steps to get started:
+
+1. Install Bun by following the instructions on the [Bun website](https://bun.sh/).
+2. Use `bun install` to install the required dependencies.
+3. Use `bun run build` to build the TypeScript project.
+4. Use `bun run start` to run the selfbot.
+
 Thank you for your contributions and support!

--- a/README.md
+++ b/README.md
@@ -27,19 +27,19 @@ This selfbot utilizes a local database and has the option to utilize external da
 
 2. Install the required dependencies:
    ```
-   npm install
+   bun install
    ```
 
 3. Configure the selfbot by editing the `.env` file with your database connection details and other configurations.
 
 4. Build the TypeScript project:
    ```
-   npm run build
+   bun run build
    ```
 
 5. Run the selfbot:
    ```
-   npm start
+   bun run start
    ```
 
 ## Basic Usage

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A selfbot for Discord with various utility and moderation features.",
   "main": "dist/selfbot.js",
   "scripts": {
-    "build": "tsc",
-    "start": "node dist/selfbot.js"
+    "build": "bun run tsc",
+    "start": "bun run node dist/selfbot.js"
   },
   "dependencies": {
     "discord.js-selfbot-v13": "^3.4.1",


### PR DESCRIPTION
Migrate the project to use Bun instead of npm.

* **package.json**
  - Update `scripts` to use `bun` commands for build and start.
* **README.md**
  - Update setup instructions to use `bun` instead of `npm`.
* **CONTRIBUTING.md**
  - Add a new section for using Bun, including installation and usage instructions.

